### PR TITLE
Properly encode paths

### DIFF
--- a/test/list-dir.scm
+++ b/test/list-dir.scm
@@ -12,7 +12,8 @@
 
 (unless (file-exists? "dir")
   (create-directory "dir")
-  (create-directory (make-pathname "dir" "another-dir"))
+  (create-directory (make-pathname "dir" "another dir [] with () special chars"))
+  (create-directory (make-pathname "dir/another dir [] with () special chars" "subdir"))
   (with-output-to-file (make-pathname "dir" "1.txt") (cut display ""))
   (with-output-to-file (make-pathname "dir" "2.txt") (cut display "")))
 
@@ -31,7 +32,7 @@
       (body
        (div (@ (id "content"))
             (h2 "Index of " (code ,path) ":")
-            (p (a (@ (href ,(or (pathname-directory path) path)))
+            (p (a (@ (href ,(encode-path (or (pathname-directory path) path))))
                   "Go to parent directory"))
             ,contents))))))
 


### PR DESCRIPTION
The original spiffy-directory-listing would only html-encode paths to
files.  This is obviously completely bogus; the path strings need to
get everything except slashes encoded.

Without this change, paths containing spaces or brackets of any kind
would result in links which caused the server to reject the request,
because the resulting URI would be invalid.  Browsers aren't always
smart enough to properly encode all special characters (which makes
sense, because they shouldn't mess with URIs, but they sometimes do,
which means we never really noticed this).

Also expose encode-path so that the example program used for testing
can encode paths correctly.

This change is basically a port of the change I made in Spiffy's simple-directory-handler which I pushed as part of the new spiffy release 6.3 I just made.